### PR TITLE
This pull request is about the implementation of get_game_history.

### DIFF
--- a/src/schnapsen/cli.py
+++ b/src/schnapsen/cli.py
@@ -59,3 +59,28 @@ def try_24_game() -> None:
     bot2 = RandBot(464566)
     for i in range(1000):
         engine.play_game(bot1, bot2, random.Random(i))
+
+
+class HistoryBot(schnapsen.game.Bot):
+    def __init__(self, seed: int) -> None:
+        self.seed = seed
+        self.rng = random.Random(self.seed)
+
+    def get_move(self, state: schnapsen.game.PlayerGameState, leader_move: Optional[schnapsen.game.PartialTrick]) -> schnapsen.game.Move:
+        history = state.get_game_history()
+        print(history)
+
+        moves = state.valid_moves()
+        move = self.rng.choice(list(moves))
+        return move
+
+    def __repr__(self) -> str:
+        return f"HistoryBot(seed={self.seed})"
+
+
+@main.command()
+def try_history() -> None:
+    engine = schnapsen.game.SchnapsenGamePlayEngine()
+    bot1 = HistoryBot(12112121)
+    bot2 = HistoryBot(464566)
+    engine.play_game(bot1, bot2, random.Random(1))

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -304,7 +304,7 @@ class GameTest(TestCase):
         talon = Talon(cards=[Card.ACE_HEARTS], trump_suit=Suit.HEARTS)
 
         gs = GameState(
-            leader=leader, follower=follower, talon=talon, previous_state=None, previous_trick=None
+            leader=leader, follower=follower, talon=talon, previous=None
         )
         self.assertFalse(gs.are_all_cards_played())
 
@@ -346,7 +346,7 @@ class GameTest(TestCase):
         talon = Talon(cards=[Card.ACE_HEARTS], trump_suit=Suit.HEARTS)
 
         gs = GameState(
-            leader=leader, follower=follower, talon=talon, previous_state=None, previous_trick=None
+            leader=leader, follower=follower, talon=talon, previous=None
         )
         sgpe = SchnapsenGamePlayEngine()
         lgs = LeaderGameState(state=gs, engine=sgpe)
@@ -407,7 +407,7 @@ class GameTest(TestCase):
         talon = Talon(cards=[Card.ACE_HEARTS], trump_suit=Suit.HEARTS)
 
         gs = GameState(
-            leader=leader, follower=follower, talon=talon, previous_state=None, previous_trick=None
+            leader=leader, follower=follower, talon=talon, previous=None
         )
         sgpe = SchnapsenGamePlayEngine()
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -109,12 +109,12 @@ class ReprTest(TestCase):
         )
 
         gs = GameState(
-            leader=leader, follower=follower, talon=talon, previous_state=None, previous_trick=None
+            leader=leader, follower=follower, talon=talon, previous=None
         )
         output_gs = str(gs)
         self.assertEqual(
             output_gs,
-            "GameState(leader=BotState(implementation=RandBot(seed=42), hand=Hand(cards=[Card.ACE_CLUBS, Card.FIVE_CLUBS, Card.NINE_HEARTS, Card.SEVEN_CLUBS], max_size=5), bot_id=0, score=Score(direct_points=4, pending_points=2), won_cards=[Card.ACE_DIAMONDS]), follower=BotState(implementation=RandBot(seed=43), hand=Hand(cards=[Card.ACE_SPADES, Card.FIVE_HEARTS, Card.NINE_CLUBS, Card.SEVEN_SPADES], max_size=5), bot_id=1, score=Score(direct_points=2, pending_points=4), won_cards=[Card.NINE_DIAMONDS]), talon=Talon(cards=[Card.ACE_HEARTS], trump_suit=HEARTS), previous_state=None, previous_trick=None)",
+            "GameState(leader=BotState(implementation=RandBot(seed=42), hand=Hand(cards=[Card.ACE_CLUBS, Card.FIVE_CLUBS, Card.NINE_HEARTS, Card.SEVEN_CLUBS], max_size=5), bot_id=0, score=Score(direct_points=4, pending_points=2), won_cards=[Card.ACE_DIAMONDS]), follower=BotState(implementation=RandBot(seed=43), hand=Hand(cards=[Card.ACE_SPADES, Card.FIVE_HEARTS, Card.NINE_CLUBS, Card.SEVEN_SPADES], max_size=5), bot_id=1, score=Score(direct_points=2, pending_points=4), won_cards=[Card.NINE_DIAMONDS]), talon=Talon(cards=[Card.ACE_HEARTS], trump_suit=HEARTS), previous=None)",
         )
 
         te = Trump_Exchange(jack=Card.JACK_SPADES)


### PR DESCRIPTION
Implemented get_game_history in PlayerGameState.
To do this, moved the previous information out of GameState into its own object, which also keeps track on changes in the leadership. The Concrete PlayerState classes now also implement am_i_leader()->bool which indicates whether we are leading or following. Added a historybot to the CLI to test this out

Trigger CI