### PR TITLE
Replace the Random object with seed number for the rdeepbot

### DIFF
--- a/executables/cli.py
+++ b/executables/cli.py
@@ -95,7 +95,7 @@ def rdeep_game() -> None:
     bot1: Bot
     bot2: Bot
     engine = SchnapsenGamePlayEngine()
-    rdeep = bot1 = RdeepBot(num_samples=16, depth=4, rand=random.Random(4564654644))
+    rdeep = bot1 = RdeepBot(num_samples=16, depth=4, seed=4564654644)
     bot2 = RandBot(464566)
     wins = 0
     amount = 100
@@ -123,9 +123,9 @@ def create_replay_memory_dataset() -> None:
     replay_memory_location = pathlib.Path(replay_memory_dir) / replay_memory_filename
 
     bot_1_behaviour: Bot = RandBot(5234243)
-    # bot_1_behaviour: Bot = RdeepBot(num_samples=4, depth=4, rand=random.Random(4564654644))
+    # bot_1_behaviour: Bot = RdeepBot(num_samples=4, depth=4, seed=4564654644)
     bot_2_behaviour: Bot = RandBot(54354)
-    # bot_2_behaviour: Bot = RdeepBot(num_samples=4, depth=4, rand=random.Random(68438))
+    # bot_2_behaviour: Bot = RdeepBot(num_samples=4, depth=4, seed=68438)
     delete_existing_older_dataset = False
 
     # check if needed to delete any older versions of the dataset
@@ -200,7 +200,7 @@ def game_24() -> None:
 def game_ace_one() -> None:
     engine = AceOneGamePlayEngine()
     bot1 = RandBot(12112121)
-    bot2 = RdeepBot(num_samples=16, depth=4, rand=random.Random(464566))
+    bot2 = RdeepBot(num_samples=16, depth=4, seed=464566)
     for i in range(1000):
         winner_id, game_points, score = engine.play_game(bot1, bot2, random.Random(i))
         print(f"Game ended. Winner is {winner_id} with {game_points} points, score {score}")

--- a/executables/server.py
+++ b/executables/server.py
@@ -19,7 +19,7 @@ def main(bot: str) -> None:
         elif bot.lower() in ["alphabeta", "alphabetabot"]:
             bot1 = AlphaBetaBot()
         elif bot.lower() == "rdeepbot":
-            bot1 = RdeepBot(num_samples=16, depth=4, rand=random.Random(42))
+            bot1 = RdeepBot(num_samples=16, depth=4, seed=42)
         else:
             raise NotImplementedError
         bot2 = s.make_gui_bot(name="mybot2")

--- a/src/schnapsen/bots/rdeep.py
+++ b/src/schnapsen/bots/rdeep.py
@@ -4,19 +4,20 @@ from random import Random
 
 
 class RdeepBot(Bot):
-    def __init__(self, num_samples: int, depth: int, rand: Random) -> None:
+    def __init__(self, num_samples: int, depth: int, seed: int) -> None:
         """
         Create a new rdeep bot.
 
         :param num_samples: how many samples to take per move
         :param depth: how deep to sample
-        :param rand: the source of randomness for this Bot
+        :param rand: the seed number for the source of randomness for this Bot
         """
         assert num_samples >= 1, f"we cannot work with less than one sample, got {num_samples}"
         assert depth >= 1, f"it does not make sense to use a dept <1. got {depth}"
         self.__num_samples = num_samples
         self.__depth = depth
-        self.__rand = rand
+        self.seed = seed
+        self.__rand = Random(self.seed)
 
     def get_move(self, state: PlayerPerspective, leader_move: Optional[Move]) -> Move:
         # get the list of valid moves, and shuffle it such


### PR DESCRIPTION
Currently, bots take either a seed number or a `random.Random` object. 
To make them consistent, I make every bot to take a seed number, wherever randomness is required, instead of a `random.Random` object. 